### PR TITLE
imp(all): use typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 coverage.json
 typechain
 typechain-types
+.DS_Store
 
 # Hardhat files
 cache

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,8 +1,20 @@
-require("@nomicfoundation/hardhat-toolbox");
-require("dotenv").config();
+import { HardhatUserConfig } from "hardhat/types";
+import "@nomicfoundation/hardhat-toolbox";
+import { config } from "dotenv";
 
-/** @type import('hardhat/config').HardhatUserConfig */
-module.exports = {
+// Load environment variables
+config();
+
+// Check that the required environment variables are set
+if (
+  !process.env.LOCAL_KEYS
+  || !process.env.TESTNET_KEYS
+  || !process.env.MAINNET_KEYS
+) {
+  throw new Error("LOCAL_KEYS environment variable is not set");
+}
+
+const hardhatConfig: HardhatUserConfig = {
   solidity: "0.8.20",
   networks: {
     evmoslocal: {
@@ -22,3 +34,5 @@ module.exports = {
     },
   },
 };
+
+export default hardhatConfig;

--- a/test/staking/testDelegateFullFlow.ts
+++ b/test/staking/testDelegateFullFlow.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Signer } from 'ethers';
+import { StakingI } from '../../typechain-types';
+import { PageRequestStruct, ValidatorStructOutput } from '../../typechain-types/contracts/Staking.sol/StakingI';
+
+describe("Testing delegation directly calling staking extension", function() {
+  const delegationAmount = ethers.parseEther("1");
+  let dev0Addr: string;
+  let delegationAmountPre: bigint;
+  let staking: StakingI;
+  let validator: string;
+
+  it("should list all available validators", async function() {
+    staking = await ethers.getContractAt(
+      'StakingI',
+      '0x0000000000000000000000000000000000000800'
+    );
+
+    const pageRequest: PageRequestStruct = {
+      key: new Uint8Array(),
+      offset: 0,
+      limit: 0,
+      countTotal: false,
+      reverse: false,
+    };
+
+    const validatorsRes = await staking.validators(
+      "BOND_STATUS_BONDED",
+      pageRequest
+    );
+    expect(
+      validatorsRes.validators.length
+    ).to.be.equal(1, "There should be one validator");
+
+    const valOut = validatorsRes.validators[0];
+    validator = valOut["operatorAddress"];
+  })
+
+  it("should show the delegation prior to delegation", async function() {
+    const signers = await ethers.getSigners();
+    const dev0 = signers[0];
+    dev0Addr = await dev0.getAddress();
+
+    const delegationsRes = await staking.delegation(
+      dev0.getAddress(),
+      validator
+    );
+    const delegationCoin = delegationsRes["balance"];
+    delegationAmountPre = delegationCoin["amount"];
+    expect(
+      delegationAmountPre
+    ).to.be.greaterThan(
+      0, "There should be an initial delegation prior to delegating"
+    );
+  })
+
+  it("should delegate to the validator", async function() {
+    const tx = await staking.delegate(
+      dev0Addr,
+      validator,
+      delegationAmount
+    );
+    const receipt = await tx.wait();
+    expect(receipt).to.not.be.null;
+    if (receipt !== null) {
+      expect(receipt.status).to.be.equal(1, "Transaction should succeed");
+    }
+  })
+
+  it("should have increased the delegation amount", async function() {
+    const delegationsRes = await staking.delegation(
+      dev0Addr,
+      validator
+    );
+
+    const delegationCoin = delegationsRes["balance"];
+    const delegationAmountPost = delegationCoin["amount"];
+    expect(
+      delegationAmountPost
+    ).to.be.equal(
+      delegationAmountPre + delegationAmount,
+      "Delegation amount should have increased by 1 ether"
+    );
+  })
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
This PR adds the configuration to use typescript within the testing repository.
It also adds an example test using the typescript implementation. This can be run using 

```bash
npx hardhat test --network evmoslocal
```